### PR TITLE
Feature addition: Configurable requested codec from Nest

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -35,6 +35,13 @@
       "required": true,
       "description": "Ensure that the installed ffmpeg binary has support for the specified codec."
     },
+    "nestStreamDesired": {
+      "title": "Nest Video Stream Desired",
+      "type": "string",
+      "default": "",
+      "required": true,
+      "description": "Manually set the video stream you wish to retrieve from Nest. Users of the `copy` codec may find setting this to `VIDEO_H264_100KBIT_L30` beneficial."
+    },
     "options": {
       "title": "Options",
       "type": "object",

--- a/lib/nestcam.js
+++ b/lib/nestcam.js
@@ -110,6 +110,9 @@ class NestCam {
     if (config.ffmpegCodec) {
       self.ffmpegCodec = config.ffmpegCodec;
     }
+    if (config.nestStreamDesired) {
+      self.nestStreamDesired = config.nestStreamDesired;
+    }
     self.services = [];
     self.streamControllers = [];
 
@@ -214,7 +217,7 @@ class NestCam {
 
     if (self.enabled) {
       let sessionID = uuid.unparse(request['sessionID']);
-      let streamer = new NexusStreamer(self.nexusTalkHost, self.uuid, self.api.accessToken, self.ffmpegCodec, self.pathToFfmpeg, self.log);
+      let streamer = new NexusStreamer(self.nexusTalkHost, self.uuid, self.api.accessToken, self.ffmpegCodec, self.nestStreamDesired, self.pathToFfmpeg, self.log);
       self.sessions[`${sessionID}`] = streamer;
       streamer.prepareStream(request, callback);
     }

--- a/lib/streamer.js
+++ b/lib/streamer.js
@@ -20,12 +20,13 @@ const AuthorizeRequest = require('./protos/AuthorizeRequest.js').AuthorizeReques
 const NestEndpoints = require('./nest-endpoints.js');
 
 class NexusStreamer extends EventEmitter {
-  constructor(host, cameraUUID, accessToken, ffmpegCodec, pathToFfmpeg, log) {
+  constructor(host, cameraUUID, accessToken, ffmpegCodec, nestStreamDesired, pathToFfmpeg, log) {
     super();
     let self = this;
     self.isStreaming = false;
     self.authorized = false;
     self.ffmpegCodec = ffmpegCodec;
+    self.nestStreamDesired = nestStreamDesired;
     self.customFfmpeg = pathToFfmpeg;
     self.log = log;
     self.sessionID = Math.floor(Math.random() * 100);
@@ -216,6 +217,10 @@ class NexusStreamer extends EventEmitter {
         StreamProfile.AVPROFILE_HD_MAIN_1
       ]
     };
+    if (self.nestStreamDesired) {
+      request.profile = StreamProfile[self.nestStreamDesired];
+      delete request.other_profiles;
+    }
     let pbfContainer = new PBF();
     StartPlayback.write(request, pbfContainer);
     let buffer = pbfContainer.finish();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-nest-cam2",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "Nest cam plugin for homebridge: https://homebridge.io/",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
Hey there!

I noticed that when I was using the `copy` codec on my Raspberry Pi (to save me from CPU hell, and from the crap quality of `h264_omx`), that the frames were jumpy / out of order.

I ended up down quite a rabbit hole which has led me to this PR. For my use case, it turns out that instead of requesting `AVPROFILE_HD_MAIN_1` from Nest (and some others, in `other_profiles`), if I request `VIDEO_H264_100KBIT_L30`, I get low-quality-but-usable video, with no jittering/jumping.

This PR adds the ability to request a custom profile